### PR TITLE
Fix: improve displayed buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ require('buffertabs').setup({
     ---@type string
     hl_group_inactive = 'Comment',
 
-    ---@type table<string>
-    exclude = { 'NvimTree', 'help', 'dashboard', 'lir', 'alpha' },
+    ---@type table[]
+    exclude = {},
+
+    ---@type boolean
+    show_all = false,
 
     ---@type 'row'|'column'
     display = 'row',

--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -24,8 +24,10 @@ local cfg = {
     hl_group = 'Keyword',
     ---@type string
     hl_group_inactive = 'Comment',
-    ---@type table<string>
-    exclude = { 'NvimTree', 'help', 'dashboard', 'lir', 'alpha' },
+    ---@type string[]
+    exclude = {},
+    ---@type boolean
+    show_all = false,
     ---@type 'row'|'column'
     display = 'row',
     ---@type 'left'|'right'|'center'
@@ -38,28 +40,39 @@ local cfg = {
 local function load_buffers()
     data = {}
 
-    for _, buf in pairs(api.nvim_list_bufs()) do
-        local is_valid = api.nvim_buf_is_valid(buf)
+    local bufs = api.nvim_list_bufs()
+    bufs = vim.tbl_filter(function(buf)
+        if cfg.show_all then
+            return true
+        end
+
         local is_loaded = api.nvim_buf_is_loaded(buf)
+        local is_listed = vim.fn.buflisted(buf) == 1
 
-        if is_valid and is_loaded then
-            local name = api.nvim_buf_get_name(buf):match("[^\\/]+$") or ""
-            local ext = string.match(name, "%w+%.(.+)") or name
-            local icon = U.get_icon(name, ext, cfg)
+        if not (is_loaded and is_listed) then
+            return false
+        end
 
-            local ft = api.nvim_get_option_value('ft', { buf = buf })
-            local is_excluded = vim.tbl_contains(cfg.exclude, ft)
+        return true
+    end, bufs)
 
-            if not is_excluded and name ~= "" then
-                local is_active = api.nvim_get_current_buf() == buf
+    for _, buf in pairs(bufs) do
+        local name = api.nvim_buf_get_name(buf):match("[^\\/]+$") or ""
+        local ext = string.match(name, "%w+%.(.+)") or name
+        local icon = U.get_icon(name, ext, cfg)
 
-                table.insert(data, {
-                    win = nil,
-                    win_buf = nil,
-                    name = icon .. " " .. name .. "",
-                    active = is_active,
-                })
-            end
+        local ft = api.nvim_get_option_value('ft', { buf = buf })
+        local is_excluded = vim.tbl_contains(cfg.exclude, ft)
+
+        if not is_excluded and name ~= "" then
+            local is_active = api.nvim_get_current_buf() == buf
+
+            table.insert(data, {
+                win = nil,
+                win_buf = nil,
+                name = icon .. " " .. name .. "",
+                active = is_active,
+            })
         end
     end
 end

--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -47,7 +47,7 @@ local function load_buffers()
             local ext = string.match(name, "%w+%.(.+)") or name
             local icon = U.get_icon(name, ext, cfg)
 
-            local ft = api.nvim_buf_get_option(buf, 'ft')
+            local ft = api.nvim_get_option_value('ft', { buf = buf })
             local is_excluded = vim.tbl_contains(cfg.exclude, ft)
 
             if not is_excluded and name ~= "" then
@@ -119,17 +119,17 @@ local function create_win(name, is_active, data_idx)
     data[data_idx].win = win
 
     -- configure window
-    api.nvim_buf_set_option(buf, 'modifiable', false)
-    api.nvim_buf_set_option(buf, 'buflisted', false)
+    api.nvim_set_option_value('modifiable', false, { buf = buf })
+    api.nvim_set_option_value('buflisted', false, { buf = buf })
 
 
     -- add highlight
     if is_active then
         api.nvim_buf_add_highlight(buf, ns, cfg.hl_group, 0, 0, -1)
-        api.nvim_win_set_option(win, 'winhighlight', 'FloatBorder:' .. cfg.hl_group)
+        api.nvim_set_option_value('winhighlight', 'FloatBorder:' .. cfg.hl_group, { win = win })
     else
         api.nvim_buf_add_highlight(buf, ns, cfg.hl_group_inactive, 0, 0, -1)
-        api.nvim_win_set_option(win, 'winhighlight', 'FloatBorder:' .. cfg.hl_group_inactive)
+        api.nvim_set_option_value('winhighlight', 'FloatBorder:' .. cfg.hl_group_inactive, { win = win })
     end
 end
 

--- a/lua/buffertabs/utils.lua
+++ b/lua/buffertabs/utils.lua
@@ -92,6 +92,6 @@ function U.get_position_vertical(pos)
     end
 end
 
-U.events = { 'BufEnter', 'BufAdd', 'BufDelete', 'InsertChange', 'VimResized' }
+U.events = { 'TermEnter', 'BufEnter', 'BufAdd', 'BufDelete', 'InsertChange', 'VimResized' }
 
 return U


### PR DESCRIPTION
This PR fixes the following issues.

- buffers with `buflisted` set to `false` are also displayed
- terminal buffers are not displayed immediately after opening
