### PR TITLE
add configurable padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ require('buffertabs').setup({
     ---@type 'none'|'single'|'double'|'rounded'|'solid'|'shadow'|table
     border = 'rounded',
 
+    ---@type integer
+    padding = 1
+
     ---@type boolean
     icons = true,
 

--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -18,6 +18,8 @@ local ns = api.nvim_create_namespace('buffertabs')
 local cfg = {
     ---@type 'none'|'single'|'double'|'rounded'|'solid'|'shadow'|table
     border = 'rounded',
+    ---@type integer
+    padding = 1,
     ---@type boolean
     icons = true,
     ---@type string
@@ -91,7 +93,7 @@ local function create_win(name, is_active, data_idx)
         if cfg.display == 'row' then
             res.row = U.get_position_vertical(cfg.vertical)
             res.col = width + 3
-            width = width + #name + 3
+            width = width + #name + cfg.padding + 1
         end
 
         if cfg.display == 'column' then
@@ -104,7 +106,7 @@ local function create_win(name, is_active, data_idx)
             end
 
             res.row = width
-            width = width + 3
+            width = width + cfg.padding + 2
         end
 
         return res


### PR DESCRIPTION
Thanks for making this awesome plugin!

The spacing in BufferTabs is very generous with the setting `border = 'none'`.
This PR enables a configurable padding that works in both 'row' and 'column' layout and does not change the default look.