### PR TITLE
fix: remove `cfg.exclude`

### DIFF
--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -63,10 +63,7 @@ local function load_buffers(d_buf)
         local ext = string.match(name, "%w+%.(.+)") or name
         local icon = U.get_icon(name, ext, cfg)
 
-        local ft = api.nvim_get_option_value('ft', { buf = buf })
-        local is_excluded = vim.tbl_contains(cfg.exclude, ft)
-
-        if not is_excluded and name ~= "" then
+        if name ~= "" then
             local is_active = api.nvim_get_current_buf() == buf
 
             table.insert(data, {


### PR DESCRIPTION
`cfg.exclude` is removed at edc0aafdf9c8ce3c5143b5f0377e555038c9db9e, but the reference remained, so I remove it.

it fixes the error below.
```
BufEnter Autocommands for "*" の処理中にエラーが検出されました:
Error executing lua callback: vim/shared.lua:0: t: expected table, got nil
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        vim/shared.lua: in function 'tbl_contains'
        .../share/nvim/lazy/BufferTabs.nvim/lua/buffertabs/init.lua:67: in function 'load_buffers'
        .../share/nvim/lazy/BufferTabs.nvim/lua/buffertabs/init.lua:185: in function <.../share/nvim/lazy/BufferTabs.nvim/lua/buffertabs/init.lua:180>
```