### PR TITLE
Feat: Added support to show buffer id along with the name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ require('buffertabs').setup({
     vertical = 'top',
 
     ---@type number in ms (recommend 2000)
-    timeout = 0
+    timeout = 0,
+    
+    ---@type boolean
+    show_id = false
+
 })
 
 ```

--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -41,7 +41,9 @@ local cfg = {
     ---@type 'top'|'bottom'|'center'
     vertical = 'top',
     ---@type number ms
-    timeout = 0
+    timeout = 0,
+    ---@type boolean
+    show_id = false
 }
 
 
@@ -70,11 +72,16 @@ local function load_buffers(d_buf)
 
         if name ~= "" then
             local is_active = api.nvim_get_current_buf() == buf
-
+            local final_name = ""
+            if cfg.show_id then
+                final_name = icon .. " " .. buf .. ". " .. name .. ""
+            else
+                final_name = icon .. " " .. name .. ""
+            end
             table.insert(data, {
                 win = nil,
                 win_buf = nil,
-                name = icon .. " " .. name .. "",
+                name = final_name,
                 active = is_active,
                 modified = is_modified,
             })


### PR DESCRIPTION
Added a `show_id` flag which adds the buffer id after the icon.

This change makes it easier for the user to quickly switch buffers using the `:b#` keymap (# being the buffer id)