### PR TITLE
Add new options for limiting amount of buffer tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,12 @@ require('buffertabs').setup({
 
     ---@type number in ms (recommend 2000)
     timeout = 0,
-    
+
     ---@type boolean
     show_id = false
 
+    ---@type integer
+    max_buffers = 0
 })
 
 ```

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ require('buffertabs').setup({
 
     ---@type integer
     max_buffers = 0
+
+    ---@type integer
+    surround_active_buffer = 0
 })
 
 ```

--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -58,6 +58,10 @@ local function load_buffers(d_buf)
     local bufs = api.nvim_list_bufs()
 
     bufs = vim.tbl_filter(function(buf)
+        if cfg.show_all then
+            return true
+        end
+
         local is_loaded = api.nvim_buf_is_loaded(buf)
         local is_listed = vim.fn.buflisted(buf) == 1
 

--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -201,7 +201,7 @@ local function display_buffers()
 
         local total_shown = 0
         for idx = lowest_idx, highest_idx do
-            total = total + 1
+            total_shown = total_shown + 1
             local buffer_idx = idx % buffer_count -- Wrap around to start of list
             if buffer_idx <= 0 then buffer_idx = buffer_count + buffer_idx end -- Wrap around to end of list
             local buffer_data = data[buffer_idx]

--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -43,7 +43,9 @@ local cfg = {
     ---@type number ms
     timeout = 0,
     ---@type boolean
-    show_id = false
+    show_id = false,
+    ---@type integer
+    max_buffers = 0,
 }
 
 
@@ -168,14 +170,15 @@ local function display_buffers()
     local max = U.get_max_width(data, cfg)
     width = U.get_position_horizontal(cfg, max, #data)
 
-    for idx, v in pairs(data) do
-        if #data == 1 and not cfg.show_single_buffer then
-            return
-        end
+    local buffer_count = #data
 
-        create_win(v.name, v.active, v.modified, idx)
+    if cfg.show_single_buffer == false and buffer_count <= 1 then
+        return
     end
-end
+
+    if cfg.max_buffers > 0 and buffer_count > cfg.max_buffers then
+        return
+    end
 
 
 ---@param opts table

--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -46,6 +46,8 @@ local cfg = {
     show_id = false,
     ---@type integer
     max_buffers = 0,
+    ---@type integer
+    surround_active_buffer = 0,
 }
 
 
@@ -180,6 +182,37 @@ local function display_buffers()
         return
     end
 
+    -- It only makes sense to show the surrounding buffers if there are enough buffers to show
+    local minimum_buffers_to_show = 2 * cfg.surround_active_buffer + 1
+
+    if cfg.surround_active_buffer > 0 and buffer_count >= minimum_buffers_to_show then
+
+        -- Find the index of the active buffer
+        local active_index = nil
+        for idx, v in pairs(data) do
+            if v.active then
+                active_index = idx
+                break
+            end
+        end
+
+        local lowest_idx = active_index - cfg.surround_active_buffer
+        local highest_idx = active_index + cfg.surround_active_buffer
+
+        local total_shown = 0
+        for idx = lowest_idx, highest_idx do
+            total = total + 1
+            local buffer_idx = idx % buffer_count -- Wrap around to start of list
+            if buffer_idx <= 0 then buffer_idx = buffer_count + buffer_idx end -- Wrap around to end of list
+            local buffer_data = data[buffer_idx]
+            create_win(buffer_data.name, buffer_data.active, buffer_data.modified, total_shown)
+        end
+    else
+        for idx, v in pairs(data) do
+            create_win(v.name, v.active, v.modified, idx)
+        end
+    end
+end
 
 ---@param opts table
 function M.setup(opts)


### PR DESCRIPTION
This introduces two new features.

## `max_buffers` which disables the tabs if there are more buffers than you specify

This is helpful when you have a lot of buffers open and the tabs dont fit on the screen.

The default value is 0 which is current behaviour where you can have as many buffer tabs as you want

## `surround_active_buffer` which only shows tabs for the active buffer and a number of buffers either side

This is a similar but slightly different use case, I had intended to introduce an option such as `max_buffer_tabs`, which unlike above didn't stop rendering tabs but just capped the amount that could be rendered. After trying this out I found what was more useful was to have a limited amount of tabs either side of the current buffer so you can see what you would access with `:bnext` and `:bprevious`

The default value is 0 which is current behaviour

Also, if there are not enough buffers open to fill out `surround_active_buffer` tabs to either side of the current buffer, we fall back to current behaviour.