### PR TITLE
Fix bug when no active buffer can be found

### DIFF
--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -15,6 +15,7 @@ local width = 0
 local is_enabled = false
 local ns = api.nvim_create_namespace('buffertabs')
 local timer = nil
+local active_index = nil
 
 ---@class Config
 local cfg = {
@@ -192,7 +193,6 @@ local function display_buffers()
     if cfg.surround_active_buffer > 0 and buffer_count >= minimum_buffers_to_show then
 
         -- Find the index of the active buffer
-        local active_index = nil
         for idx, v in pairs(data) do
             if v.active then
                 active_index = idx

--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -200,6 +200,11 @@ local function display_buffers()
             end
         end
 
+        -- If there is no active buffer, such as when telescope is open, dont show buffer tabs
+        if active_index == nil then
+            return
+        end
+
         local lowest_idx = active_index - cfg.surround_active_buffer
         local highest_idx = active_index + cfg.surround_active_buffer
 


### PR DESCRIPTION
Currently if there is no active buffer, such as when we open a telescope window and we have set `surround_active_buffer` we will get an error.

`active_index` is now persisted so we can fallback to using the last active buffer in these cases.

However, if for some reason `active_index` has not been set yet we just fallback to not showing tabs when there is no active buffer.