### PR TITLE
Fix rendering issue and introduce new options

### DIFF
--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -83,9 +83,9 @@ local function load_buffers(d_buf)
             local is_active = api.nvim_get_current_buf() == buf
             local final_name = ""
             if cfg.show_id then
-                final_name = icon .. " " .. buf .. ". " .. name .. ""
+                final_name = icon .. buf .. ". " .. name
             else
-                final_name = icon .. " " .. name .. ""
+                final_name = icon .. name
             end
             table.insert(data, {
                 win = nil,
@@ -104,6 +104,8 @@ end
 ---@param is_modified boolean
 ---@param data_idx number
 local function create_win(name, is_active, is_modified, data_idx)
+    local modified_width = is_modified and vim.fn.strdisplaywidth(cfg.modified) or 0
+
     local function get_position()
         local res = {
             row = 0,
@@ -113,16 +115,16 @@ local function create_win(name, is_active, is_modified, data_idx)
         if cfg.display == 'row' then
             res.row = U.get_position_vertical(cfg.vertical)
             res.col = width + 3 -- padding at left side
-            width = width + #name + #cfg.modified + cfg.padding + 3
+            width = width + vim.fn.strdisplaywidth(name) + cfg.padding + modified_width + 3
         end
 
         if cfg.display == 'column' then
             if cfg.horizontal == 'left' then
                 res.col = 0
             elseif cfg.horizontal == 'right' then
-                res.col = vim.o.columns - (#name + #cfg.modified)
+                res.col = vim.o.columns - (vim.fn.strdisplaywidth(name) + modified_width)
             else
-                res.col = vim.o.columns / 2 - #name / 2
+                res.col = vim.o.columns / 2 - vim.fn.strdisplaywidth(name) / 2
             end
 
             res.row = width
@@ -134,12 +136,11 @@ local function create_win(name, is_active, is_modified, data_idx)
 
     -- setup buffer
     local buf = api.nvim_create_buf(false, true)
-    local modified_icon = is_modified and cfg.modified or ""
-    modified_icon = #cfg.modified == 0 and "" or modified_icon -- if you dont want icon
+    local modified = is_modified and cfg.modified or ""
 
     data[data_idx].win_buf = buf
     api.nvim_buf_set_lines(buf, 0, -1, true,
-        { " " .. name .. modified_icon .. " " }
+        { " " .. name .. modified .. " " }
     )
 
     local pos = get_position()
@@ -147,7 +148,7 @@ local function create_win(name, is_active, is_modified, data_idx)
     -- create window
     local win_opts = {
         relative = 'editor',
-        width = #name + #cfg.modified, -- 2 for spaces
+        width = vim.fn.strdisplaywidth(name) + modified_width + 2, -- 2 for padding
         height = 1,
         row = pos.row,
         col = pos.col,
@@ -161,7 +162,6 @@ local function create_win(name, is_active, is_modified, data_idx)
     -- configure window
     api.nvim_set_option_value('modifiable', false, { buf = buf })
     api.nvim_set_option_value('buflisted', false, { buf = buf })
-
 
     -- add highlight
     if is_active then
@@ -230,7 +230,6 @@ function M.setup(opts)
 
     cfg.hl_group = U.get_color(cfg.hl_group, 0)
     cfg.hl_group_inactive = U.get_color(cfg.hl_group_inactive, 1)
-
 
     -- start displaying
     is_enabled = true

--- a/lua/buffertabs/utils.lua
+++ b/lua/buffertabs/utils.lua
@@ -8,15 +8,15 @@ function U.get_icon(name, ext, cfg)
     local ok, dev_icons = pcall(require, 'nvim-web-devicons')
 
     if not cfg.icons then
-        return ' '
+        return ''
     end
 
     if not ok then
-        return ''
+        return ' '
     end
 
     local icon = dev_icons.get_icon(name, ext, { default = true })
-    return icon
+    return icon .. ' '
 end
 
 ---@param data Data[]


### PR DESCRIPTION
## Fix the issue when rendering without icons

This fixes the issue where the text doesn't fit in the buffer tab window when icons are set to false, this was happening because we weren't respecting utf8 length of strings.

This commit switches to using `vim.fn.strdisplaywidth` to get the actual character length of the string.

This also remedies some un-needed whitespace that is inserted when icons are disabled.

## Introduce new `show_all_listed` option

I don't usually want to use `show_all` as it will include buffers we are not able to switch to, however in cases I still want to show all listed buffers even if they haven't been loaded yet.