### PR TITLE
Make buffer tab text background match neovim background color

### DIFF
--- a/lua/buffertabs/init.lua
+++ b/lua/buffertabs/init.lua
@@ -174,10 +174,10 @@ local function create_win(name, is_active, is_modified, data_idx)
     -- add highlight
     if is_active then
         api.nvim_buf_add_highlight(buf, ns, cfg.hl_group, 0, 0, -1)
-        api.nvim_set_option_value('winhighlight', 'FloatBorder:' .. cfg.hl_group, { win = win })
+        api.nvim_set_option_value('winhighlight', 'NormalFloat:Normal,FloatBorder:' .. cfg.hl_group, { win = win })
     else
         api.nvim_buf_add_highlight(buf, ns, cfg.hl_group_inactive, 0, 0, -1)
-        api.nvim_set_option_value('winhighlight', 'FloatBorder:' .. cfg.hl_group_inactive, { win = win })
+        api.nvim_set_option_value('winhighlight', 'NormalFloat:Normal,FloatBorder:' .. cfg.hl_group_inactive, { win = win })
     end
 end
 


### PR DESCRIPTION
This avoids a different coloured block behind the text in the buffer tab